### PR TITLE
Add noCJS flag to skip the CJS build

### DIFF
--- a/src/packageJson.ts
+++ b/src/packageJson.ts
@@ -9,10 +9,10 @@ export async function copyPackageJsonFile(cwd: string, outDir: string) {
   executeCmd(`cp ${pjsonPath} ${outDir}`);
 }
 
-export async function rewritePackageJsonFile(cwd: string, outDir: string) {
+export async function rewritePackageJsonFile(cwd: string, outDir: string, noCJS: boolean) {
   const pjsonDistPath = path.join(outDir, 'package.json');
   const pjson = JSON.parse(await fs.readFile(pjsonDistPath, 'utf8')) as PackageJson;
-  pjson.main = './index.cjs.js';
+  if (!noCJS) pjson.main = './index.cjs.js';
   pjson.module = './index.js';
   pjson.types = './index.d.ts';
   delete pjson.publishConfig?.main;

--- a/src/packageJson.ts
+++ b/src/packageJson.ts
@@ -12,7 +12,7 @@ export async function copyPackageJsonFile(cwd: string, outDir: string) {
 export async function rewritePackageJsonFile(cwd: string, outDir: string, noCJS: boolean) {
   const pjsonDistPath = path.join(outDir, 'package.json');
   const pjson = JSON.parse(await fs.readFile(pjsonDistPath, 'utf8')) as PackageJson;
-  if (!noCJS) pjson.main = './index.cjs.js';
+  pjson.main = noCJS ? './index.js' : './index.cjs.js';
   pjson.module = './index.js';
   pjson.types = './index.d.ts';
   delete pjson.publishConfig?.main;


### PR DESCRIPTION
Disables the CJS build when the flag is passed. Also skips writing the main field in package.json when rewritePackageJson is passed.